### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.filmon/addon.xml
+++ b/pvr.filmon/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Stephen Denham">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.filmon/addon.xml
+++ b/pvr.filmon/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.filmon"
-  version="0.5.7"
+  version="0.6.0"
   name="PVR Filmon Client"
   provider-name="Stephen Denham">
   <requires>

--- a/pvr.filmon/changelog.txt
+++ b/pvr.filmon/changelog.txt
@@ -1,3 +1,6 @@
+0.6.0
+Updated to API v1.9.7
+
 0.5.7
 Updated Language files from Transifex
 

--- a/src/PVRFilmonData.cpp
+++ b/src/PVRFilmonData.cpp
@@ -353,6 +353,10 @@ PVR_ERROR PVRFilmonData::GetTimers(ADDON_HANDLE handle) {
 			PVRFilmonTimer &timer = *it;
 			if ((PVR_TIMER_STATE) timer.state < PVR_TIMER_STATE_COMPLETED) {
 				PVR_TIMER xbmcTimer;
+				memset(&xbmcTimer, 0, sizeof(PVR_TIMER));
+
+				/* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+				xbmcTimer.iTimerType = PVR_TIMER_TYPE_NONE;
 
 				xbmcTimer.iClientIndex = timer.iClientIndex;
 				xbmcTimer.iClientChannelUid = timer.iClientChannelUid;
@@ -363,7 +367,6 @@ PVR_ERROR PVRFilmonData::GetTimers(ADDON_HANDLE handle) {
 				xbmcTimer.startTime = timer.startTime;
 				xbmcTimer.endTime = timer.endTime;
 				xbmcTimer.state = (PVR_TIMER_STATE) timer.state;
-				xbmcTimer.bIsRepeating = timer.bIsRepeating;
 				xbmcTimer.firstDay = timer.firstDay;
 				xbmcTimer.iWeekdays = timer.iWeekdays;
 				xbmcTimer.iEpgUid = timer.iEpgUid;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -195,7 +195,6 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities) {
 	pCapabilities->bSupportsTimers = true;
 	pCapabilities->bSupportsChannelGroups = true;
 	pCapabilities->bSupportsRadio = false;
-	pCapabilities->bSupportsRecordingFolders = false;
 	pCapabilities->bHandlesInputStream = false;
 	pCapabilities->bHandlesDemuxing = false;
 	pCapabilities->bSupportsChannelScan = false;
@@ -315,6 +314,12 @@ PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) {
 	return m_data->DeleteRecording(recording);
 }
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+	/* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+	return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void) {
 	if (!m_data)
 		return 0;
@@ -326,6 +331,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle) {
 	if (!m_data)
 		return PVR_ERROR_SERVER_ERROR;
 
+	/* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
 	return m_data->GetTimers(handle);
 }
 
@@ -336,10 +342,11 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer) {
 	return m_data->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) {
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/) {
 	if (!m_data)
 		return PVR_ERROR_SERVER_ERROR;
 
+	/* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
 	return m_data->DeleteTimer(timer, bForceDelete);
 
 }


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.