### PR TITLE
[json] Fix missing depend and download url

### DIFF
--- a/depends/common/jsoncpp/CMakeLists.txt
+++ b/depends/common/jsoncpp/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(jsoncpp)
+
+cmake_minimum_required(VERSION 2.6)
+enable_language(CXX)
+
+set(SOURCES src/lib_json/json_reader.cpp
+            src/lib_json/json_value.cpp
+            src/lib_json/json_writer.cpp)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+add_library(jsoncpp ${SOURCES})
+
+install(TARGETS jsoncpp DESTINATION ${CMAKE_INSTALL_PREFIX}/lib) 
+install(DIRECTORY include/json DESTINATION ${CMAKE_INSTALL_PREFIX}/include/jsoncpp)

--- a/depends/common/jsoncpp/jsoncpp.txt
+++ b/depends/common/jsoncpp/jsoncpp.txt
@@ -1,0 +1,1 @@
+jsoncpp http://mirrors.kodi.tv/build-deps/sources/jsoncpp-src-0.5.0.tar.gz


### PR DESCRIPTION
Solve the mess after jsoncpp source went MIA.
Please don't use third-party server sources. Ask us to upload whatever depend you need to Kodi's mirrors.