### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.filmon/addon.xml.in
+++ b/pvr.filmon/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.filmon"
-  version="0.6.5"
+  version="0.6.6"
   name="PVR Filmon Client"
   provider-name="Stephen Denham">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.filmon/changelog.txt
+++ b/pvr.filmon/changelog.txt
@@ -1,3 +1,6 @@
+0.6.6
+Updated to PVR API v4.1.0
+
 0.6.5
 Updated to PVR API v4.0.0
 

--- a/src/PVRFilmonData.cpp
+++ b/src/PVRFilmonData.cpp
@@ -266,6 +266,7 @@ PVR_ERROR PVRFilmonData::GetEPGForChannel(ADDON_HANDLE handle,
 				tag.iEpisodeNumber = 0;
 				tag.iEpisodePartNumber = 0;
 				tag.strEpisodeName = "";
+				tag.iFlags = EPG_TAG_FLAG_UNDEFINED;
 				PVR->TransferEpgEntry(handle, &tag);
 			}
 		}


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075