### PR TITLE
[cmake] Added missing CPack include. Closes #32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,5 @@ set(FILMON_SOURCES src/client.cpp
                    src/md5.cpp)
 
 build_addon(pvr.filmon FILMON DEPLIBS)
+
+include(CPack)


### PR DESCRIPTION
@Montellese fixes #32. Good to go? 