### PR TITLE
Rename addon title to "FilmOn PVR Client Addon"

### DIFF
--- a/pvr.filmon/addon.xml.in
+++ b/pvr.filmon/addon.xml.in
@@ -2,7 +2,7 @@
 <addon
   id="pvr.filmon"
   version="1.2.1"
-  name="PVR Filmon Client"
+  name="FilmOn PVR Client Addon"
   provider-name="Stephen Denham">
   <requires>
     <c-pluff version="0.1"/>


### PR DESCRIPTION
Suggest renaming of the addon title to "FilmOn PVR Client Addon" just to try to make it a little more clear and more consistant with the naming-standard of the other PVR client addons for Kodi.