### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(JsonCpp REQUIRED)

--- a/pvr.filmon/addon.xml.in
+++ b/pvr.filmon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.filmon"
-  version="1.3.1"
+  version="1.4.0"
   name="PVR Filmon Client"
   provider-name="Stephen Denham">
   <requires>

--- a/pvr.filmon/changelog.txt
+++ b/pvr.filmon/changelog.txt
@@ -1,3 +1,6 @@
+1.4.0
+Cmake: rename find_package kodi to Kodi
+
 1.3.1
 Fix includes
 


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in