### PR TITLE
update jsoncpp methods to non deprecated versions

### DIFF
--- a/pvr.filmon/addon.xml.in
+++ b/pvr.filmon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.filmon"
-  version="2.3.0"
+  version="2.3.1"
   name="PVR Filmon Client"
   provider-name="Stephen Denham">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.filmon/changelog.txt
+++ b/pvr.filmon/changelog.txt
@@ -1,3 +1,6 @@
+2.3.1
+change to non deprecated jsoncpp methods
+
 2.3.0
 Update to PVR addon API v5.8.0
 


### PR DESCRIPTION
just updated to non deprecated 1.8.3 jsoncpp functions.

Builds, but not runtime tested. Just figured id throw this PR in to lineup with others already done. Not too fussed if its merged or not, your call really. 