### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.filmon/addon.xml.in
+++ b/pvr.filmon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.filmon"
-  version="20.0.0"
+  version="20.1.0"
   name="PVR Filmon Client"
   provider-name="Stephen Denham">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.filmon/changelog.txt
+++ b/pvr.filmon/changelog.txt
@@ -1,3 +1,8 @@
+v20.1.0
+- Kodi PVR API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
+
 v20.0.0
 - Translations updates from Weblate
   - fr_ca, mt_mt, te_in

--- a/src/PVRFilmonData.cpp
+++ b/src/PVRFilmonData.cpp
@@ -129,6 +129,7 @@ PVR_ERROR PVRFilmonData::GetCapabilities(kodi::addon::PVRCapabilities& capabilit
   capabilities.SetSupportsTV(true);
   capabilities.SetSupportsEPG(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(true);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsTimers(true);
   capabilities.SetSupportsChannelGroups(true);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Enforce EDL limits

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395